### PR TITLE
Match nicoddemus

### DIFF
--- a/projects-tests/tox/users.json
+++ b/projects-tests/tox/users.json
@@ -190,7 +190,7 @@
   "ned": null,
   "nelfin": null,
   "nicholasserra": null,
-  "nicoddemus": null,
+  "nicoddemus": true,
   "njs": null,
   "npinto": null,
   "obestwalter": true,


### PR DESCRIPTION
I assume you're supposed to set to `true` if it is the same username? If it's a different name, it should be set to the GH's username? That was not clear to me on the email sent pytest-dev@...
